### PR TITLE
request: send values in Query string instead of POST body

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,27 @@
+package recaptcha_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/odeke-em/recaptcha"
+)
+
+func Example() {
+	req := &recaptcha.Request{
+		SecretKey: "aSecretKey",
+		Response:  "goog-challenge",
+		RemoteIP:  "192.168.1.24",
+	}
+
+	res, err := req.Verify()
+	if err != nil {
+		log.Fatalf("failed to verify: %v", err)
+	}
+
+	if !res.Success {
+		log.Fatalf("failed to verify that code, errors: %v\n", res.ErrorCodes)
+	}
+
+	fmt.Printf("Successfully verified at: %v\n", res.ChallengeTimeStamp)
+}

--- a/recaptcha.go
+++ b/recaptcha.go
@@ -1,36 +1,100 @@
 package recaptcha
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"sync"
 	"time"
 )
 
 type Request struct {
+	sync.RWMutex
+
 	SecretKey string `json:"secret"`
 	Response  string `json:"response"`
 	RemoteIP  string `json:"remoteip,omitempty"`
+
+	Transport http.RoundTripper `json:"-"`
+}
+
+func (req *Request) httpClient() *http.Client {
+	req.RLock()
+	defer req.RUnlock()
+
+	if req.Transport == nil {
+		return http.DefaultClient
+	}
+
+	return &http.Client{
+		Transport: req.Transport,
+	}
 }
 
 type Response struct {
-	Success            bool          `json:"success"`
-	ChallengeTimeStamp *time.Time    `json:"challenge_ts"`
-	ErrorCodes         []interface{} `json:"error-codes"`
+	Success    bool     `json:"success"`
+	ErrorCodes []string `json:"error-codes"`
+
+	ChallengeTimeStamp *time.Time `json:"challenge_ts"`
 }
 
 const verifyURL = "https://www.google.com/recaptcha/api/siteverify"
 
+var (
+	errEmptySecretKey = errors.New("empty secretKey")
+	errEmptyResponse  = errors.New("empty response")
+	errNilRequest     = errors.New("nil request cannot be validated")
+)
+
+func (req *Request) Validate() error {
+	req.RLock()
+	defer req.RUnlock()
+
+	if req.SecretKey == "" {
+		return errEmptySecretKey
+	}
+	if req.Response == "" {
+		return errEmptyResponse
+	}
+	return nil
+}
+
 func (req *Request) Verify() (*Response, error) {
+	if req == nil {
+		return nil, errNilRequest
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	// The recaptcha documentation claims POST parameters
+	// but actually it takes in Query string keys and values
+	// so need to transform the request into url.Values then .Encode()
+	// Contrary to the claims at https://developers.google.com/recaptcha/docs/verify
+	// See https://twitter.com/odeke_et/status/846786233221222400.
 	blob, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
+	asMap := make(map[string]string)
+	_ = json.Unmarshal(blob, &asMap)
 
-	httpReq, _ := http.NewRequest("POST", verifyURL, bytes.NewReader(blob))
-	httpRes, err := http.DefaultClient.Do(httpReq)
+	hdr := make(url.Values)
+	for key, value := range asMap {
+		hdr.Add(key, value)
+	}
+	finalURL := fmt.Sprintf("%s?%s", verifyURL, hdr.Encode())
+
+	// As of Go1.8, using http.NoBody instead of nil, http.Transport
+	// doesn't recognize http.NoBody.
+	// See https://github.com/golang/go/issues/18891
+	// TODO: Use http.NoBody once that bug is fixed.
+	httpReq, _ := http.NewRequest("POST", finalURL, nil)
+	httpClient := req.httpClient()
+	httpRes, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}

--- a/recaptcha_test.go
+++ b/recaptcha_test.go
@@ -1,0 +1,204 @@
+package recaptcha_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/odeke-em/go-uuid"
+	"github.com/odeke-em/recaptcha"
+)
+
+func Example() {
+	req := &recaptcha.Request{
+		SecretKey: "aSecretKey",
+		Response:  "goog-challenge",
+		RemoteIP:  "192.168.1.24",
+	}
+
+	res, err := req.Verify()
+	if err != nil {
+		log.Fatalf("failed to verify: %v", err)
+	}
+
+	if !res.Success {
+		log.Fatalf("failed to verify that code, errors: %v\n", res.ErrorCodes)
+	}
+
+	fmt.Printf("Successfully verified at: %v\n", res.ChallengeTimeStamp)
+}
+
+func TestFullRoundTrip(t *testing.T) {
+	// Generate unique keys on every run to mimick
+	// Google's typical backend.
+	transport := &customBackend{
+		secretKey:         uuid.NewRandom().String(),
+		challengeResponse: uuid.NewRandom().String(),
+	}
+
+	tests := [...]struct {
+		req           *recaptcha.Request
+		wantResErrors []string
+		mustErr       bool
+	}{
+		0: {
+			req:     &recaptcha.Request{},
+			mustErr: true,
+			wantResErrors: []string{
+				"missing input-secret",
+				"missing input-response",
+			},
+		},
+		1: {
+			mustErr: true,
+			req: &recaptcha.Request{
+				SecretKey: "aKey",
+			},
+			wantResErrors: []string{
+				"missing input-response",
+			},
+		},
+
+		2: {
+			req: &recaptcha.Request{
+				SecretKey: "aKey",
+				Response:  "aResponse",
+			},
+			wantResErrors: []string{
+				"invalid-input-response",
+				"invalid-input-secret",
+			},
+		},
+
+		// Successful verification request
+		3: {
+			req: &recaptcha.Request{
+				SecretKey: transport.secretKey,
+				Response:  transport.challengeResponse,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		if tt.req != nil {
+			tt.req.Transport = transport
+		}
+
+		res, err := tt.req.Verify()
+		if tt.mustErr {
+			if err == nil {
+				t.Errorf("#%d: want error", i)
+			}
+			if res != nil {
+				t.Errorf("#%d: unexpectedly gave back a response", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: err=%q", i, err)
+			continue
+		}
+
+		mustSucceed := len(tt.wantResErrors) < 1
+		if mustSucceed {
+			if res == nil {
+				t.Errorf("#%d: expected a non-nil response", i)
+			} else if !res.Success {
+				t.Errorf("#%d: was expected to succeed, got : %#v", i, res)
+			}
+			continue
+		}
+
+		got, want := res.ErrorCodes, tt.wantResErrors[:]
+		// Sort them and compare
+		sort.Strings(got)
+		sort.Strings(want)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("#%d\ngot= %#v\nwant=%#v", i, got, want)
+		}
+	}
+}
+
+type customBackend struct {
+	sync.RWMutex
+	secretKey         string
+	challengeResponse string
+}
+
+var _ http.RoundTripper = (*customBackend)(nil)
+
+func (cb *customBackend) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != "POST" {
+		res := makeCodedResponse(http.StatusMethodNotAllowed, []byte("only accepts POST"))
+		return res, nil
+	}
+
+	queryValues := req.URL.Query()
+	var errsList []string
+	secretKey := queryValues.Get("secret")
+	if secretKey == "" {
+		errsList = append(errsList, "missing-input-secret")
+	}
+	response := queryValues.Get("response")
+	if response == "" {
+		errsList = append(errsList, "missing-input-response")
+	}
+
+	cb.RLock()
+	wantSecretKey, wantChallengeResponse := cb.secretKey, cb.challengeResponse
+	cb.RUnlock()
+
+	if response != wantChallengeResponse {
+		errsList = append(errsList, "invalid-input-response")
+	}
+	if secretKey != wantSecretKey {
+		errsList = append(errsList, "invalid-input-secret")
+	}
+
+	verifyRes := new(recaptcha.Response)
+	if len(errsList) < 1 {
+		verifyRes.Success = true
+		now := time.Now()
+		verifyRes.ChallengeTimeStamp = &now
+	} else {
+		verifyRes.ErrorCodes = errsList
+	}
+
+	blob, err := json.Marshal(verifyRes)
+	if err != nil {
+		res := makeCodedResponse(http.StatusInternalServerError, []byte(err.Error()))
+		return res, err
+	}
+
+	res := makeCodedResponse(http.StatusOK, blob)
+	res.Status = "200 OK"
+	res.Header = make(http.Header)
+	res.Header.Set("Content-Type", "application/json")
+
+	return res, nil
+}
+
+func makeCodedResponse(code int, body []byte) *http.Response {
+	res := &http.Response{
+		StatusCode: code,
+	}
+	if len(body) > 0 {
+		prc, pwc := io.Pipe()
+		go func() {
+			defer pwc.Close()
+			_, _ = pwc.Write(body)
+		}()
+		res.Body = prc
+	}
+
+	return res
+}


### PR DESCRIPTION
The Google reCaptcha backend apparently expects values
as query string values instead of in the POST body, despite
the documentation's claims, as I detail in issue #1 after
hours of debugging and sweating.

Also adds an example as well as a test to lock in the
discerned behavior. Whenever Google fixes their API,
these tests will fail spectacularly and we'll be able
to switch over easily.

Fixes #1.