### PR TITLE
internals: send body as postform instead of querystring

### DIFF
--- a/recaptcha.go
+++ b/recaptcha.go
@@ -3,7 +3,6 @@ package recaptcha
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -82,19 +81,13 @@ func (req *Request) Verify() (*Response, error) {
 	asMap := make(map[string]string)
 	_ = json.Unmarshal(blob, &asMap)
 
-	hdr := make(url.Values)
+	values := make(url.Values)
 	for key, value := range asMap {
-		hdr.Add(key, value)
+		values.Add(key, value)
 	}
-	finalURL := fmt.Sprintf("%s?%s", verifyURL, hdr.Encode())
 
-	// As of Go1.8, using http.NoBody instead of nil, http.Transport
-	// doesn't recognize http.NoBody.
-	// See https://github.com/golang/go/issues/18891
-	// TODO: Use http.NoBody once that bug is fixed.
-	httpReq, _ := http.NewRequest("POST", finalURL, nil)
 	httpClient := req.httpClient()
-	httpRes, err := httpClient.Do(httpReq)
+	httpRes, err := httpClient.PostForm(verifyURL, values)
 	if err != nil {
 		return nil, err
 	}

--- a/recaptcha_test.go
+++ b/recaptcha_test.go
@@ -121,13 +121,12 @@ func (cb *customBackend) RoundTrip(req *http.Request) (*http.Response, error) {
 		return res, nil
 	}
 
-	queryValues := req.URL.Query()
 	var errsList []string
-	secretKey := queryValues.Get("secret")
+	secretKey := req.PostFormValue("secret")
 	if secretKey == "" {
 		errsList = append(errsList, "missing-input-secret")
 	}
-	response := queryValues.Get("response")
+	response := req.PostFormValue("response")
 	if response == "" {
 		errsList = append(errsList, "missing-input-response")
 	}


### PR DESCRIPTION
Fixes #3.

Send the body as a post form so make a url.Values
from all the secrets to send, then make a request
whose body is "application/x-www-form-urlencoded".

Yesterday's solution didn't settle right with me
and after reading
https://www.eff.org/deeplinks/2017/03/five-creepy-things-your-isp-could-do-if-congress-repeals-fccs-privacy-protections
that drove me to fix this in class.

Now the body will be sent in the body and secrets won't be inspected
when encrypted.